### PR TITLE
Add ARPG mode configuration flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ cmake ..
 ```
 make -j$(grep processor /proc/cpuinfo | wc -l)
 ```
+
+## Configuration
+
+- `arpgMode` (default: `false`) — toggles ARPG-oriented server behavior without requiring compile-time switches.

--- a/config.lua.dist
+++ b/config.lua.dist
@@ -81,6 +81,7 @@
 	addManaSpentInPvPZone = true
 	squareColor = 0
 	allowFightback = true
+	arpgMode = false
 	fistBaseAttack = 7
 	optionalWarAttackableAlly = false
 

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -34,6 +34,7 @@ ConfigManager::ConfigManager()
 	m_confString[DATA_DIRECTORY] = m_confString[LOGS_DIRECTORY] = m_confString[IP] = m_confString[RUNFILE] = m_confString[OUTPUT_LOG] = m_confString[ENCRYPTION_KEY] = "";
 	m_confBool[LOGIN_ONLY_LOGINSERVER] = m_confBool[START_CLOSED] = false;
 	m_confBool[SCRIPT_SYSTEM] = true;
+	m_confBool[ARPG_MODE] = false;
 }
 
 bool ConfigManager::load()
@@ -288,6 +289,7 @@ bool ConfigManager::load()
 	m_confNumber[LOOT_MESSAGE_TYPE] = getGlobalNumber("monsterLootMessageType", 25);
 	m_confNumber[NAME_REPORT_TYPE] = getGlobalNumber("violationNameReportActionType", 2);
 	m_confBool[ALLOW_FIGHTBACK] = getGlobalBool("allowFightback", true);
+	m_confBool[ARPG_MODE] = getGlobalBool("arpgMode", false);
 	m_confNumber[HOUSE_CLEAN_OLD] = getGlobalNumber("houseCleanOld", 0);
 	m_confBool[VIPLIST_PER_PLAYER] = getGlobalBool("separateVipListPerCharacter", false);
 	m_confDouble[RATE_MONSTER_HEALTH] = getGlobalDouble("rateMonsterHealth", 1);
@@ -375,6 +377,11 @@ bool ConfigManager::getBool(uint32_t _what) const
 		std::clog << "[Warning - ConfigManager::getBool] " << _what << std::endl;
 
 	return false;
+}
+
+bool ConfigManager::getBoolean(uint32_t _what) const
+{
+	return getBool(_what);
 }
 
 int32_t ConfigManager::getNumber(uint32_t _what) const

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -283,6 +283,7 @@ class ConfigManager
 			ADMIN_REQUIRE_LOGIN,
 			ADDONS_PREMIUM,
 			OPTIONAL_WAR_ATTACK_ALLY,
+			ARPG_MODE,
 			ENABLE_CAST,
 			SKIP_ITEMS_VERSION,
 			BIND_ONLY_GLOBAL_ADDRESS,
@@ -298,6 +299,7 @@ class ConfigManager
 
 		const std::string& getString(uint32_t _what) const;
 		bool getBool(uint32_t _what) const;
+		bool getBoolean(uint32_t _what) const;
 		int32_t getNumber(uint32_t _what) const;
 		double getDouble(uint32_t _what) const;
 

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <fstream>
 #include <iomanip>
+#include <cassert>
 
 #ifndef WINDOWS
 #include <sys/signal.h>
@@ -422,6 +423,10 @@ void otserv(StringVec, ServiceManager* services)
 	std::clog << ">> Loading config (" << g_config.getString(ConfigManager::CONFIG_FILE) << ")" << std::endl;
 	if(!g_config.load())
 		startupErrorMessage("Unable to load " + g_config.getString(ConfigManager::CONFIG_FILE) + "!");
+
+	const bool arpgModeEnabled = g_config.getBoolean(ConfigManager::ARPG_MODE);
+	assert(ConfigManager::ARPG_MODE < ConfigManager::LAST_BOOL_CONFIG);
+	std::clog << ">> ARPG mode: " << (arpgModeEnabled ? "ON" : "OFF") << std::endl;
 
 	// silently append trailing slash
 	std::string path = g_config.getString(ConfigManager::DATA_DIRECTORY);


### PR DESCRIPTION
## Summary
- add an `arpgMode` configuration flag and expose it through the config manager
- log the ARPG mode state at startup with a sanity assert
- document the new flag for server operators

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dab95da2188330a36c68f293150b06