### PR TITLE
Add ARPG debug talk action toggles

### DIFF
--- a/data/talkactions/talkactions.xml
+++ b/data/talkactions/talkactions.xml
@@ -30,6 +30,7 @@
 
 	<!-- Gamemasters -->
 	<talkaction log="yes" words="/ghost" access="3" event="function" value="ghost"/>
+	<talkaction log="yes" words="/arpgdebug" access="3" event="function" value="arpgDebug"/>
 	<talkaction log="yes" words="/squelch" access="3" event="script" value="gamemaster.lua"/>
 	<talkaction log="yes" words="/cliport" access="3" event="script" value="gamemaster.lua"/>
 	<talkaction log="yes" words="/t" access="3" event="script" value="teleporttown.lua"/>

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -75,6 +75,10 @@ Game::Game()
 	gameState = GAMESTATE_NORMAL;
 	worldType = WORLDTYPE_OPEN;
 	map = NULL;
+	debugOverlayHitboxes = false;
+	debugOverlayEffectCount = false;
+	debugOverlayVelocityArrows = false;
+	arpgModeEnabled = false;
 	playersRecord = lastStageLevel = 0;
 	for(int32_t i = 0; i < 3; i++)
 		globalSaveMessage[i] = false;
@@ -92,6 +96,82 @@ Game::~Game()
 {
 	if(map)
 		delete map;
+}
+
+bool Game::isDebugOverlayEnabled(DebugOverlay_t overlay) const
+{
+	switch(overlay)
+	{
+		case DEBUG_OVERLAY_HITBOXES:
+			return debugOverlayHitboxes;
+		case DEBUG_OVERLAY_EFFECT_COUNT:
+			return debugOverlayEffectCount;
+		case DEBUG_OVERLAY_VELOCITY_ARROWS:
+			return debugOverlayVelocityArrows;
+		default:
+			break;
+	}
+
+	return false;
+}
+
+bool Game::setDebugOverlayEnabled(DebugOverlay_t overlay, bool enabled)
+{
+	bool current = isDebugOverlayEnabled(overlay);
+	const char* overlayName = "unknown";
+	bool* target = NULL;
+
+	switch(overlay)
+	{
+		case DEBUG_OVERLAY_HITBOXES:
+			target = &debugOverlayHitboxes;
+			overlayName = "hitboxes";
+			break;
+
+		case DEBUG_OVERLAY_EFFECT_COUNT:
+			target = &debugOverlayEffectCount;
+			overlayName = "effect count";
+			break;
+
+		case DEBUG_OVERLAY_VELOCITY_ARROWS:
+			target = &debugOverlayVelocityArrows;
+			overlayName = "velocity arrows";
+			break;
+
+		default:
+			return current;
+	}
+
+	if(target && *target != enabled)
+	{
+		*target = enabled;
+		std::clog << "[Game::setDebugOverlayEnabled] " << overlayName << " overlay "
+			<< (enabled ? "enabled" : "disabled") << std::endl;
+	}
+
+	return target ? *target : current;
+}
+
+bool Game::toggleDebugOverlay(DebugOverlay_t overlay)
+{
+	return setDebugOverlayEnabled(overlay, !isDebugOverlayEnabled(overlay));
+}
+
+bool Game::setArpgModeEnabled(bool enabled)
+{
+	if(arpgModeEnabled != enabled)
+	{
+		arpgModeEnabled = enabled;
+		std::clog << "[Game::setArpgModeEnabled] ARPG mode "
+			<< (enabled ? "enabled" : "disabled") << std::endl;
+	}
+
+	return arpgModeEnabled;
+}
+
+bool Game::toggleArpgMode()
+{
+	return setArpgModeEnabled(!arpgModeEnabled);
 }
 
 void Game::start(ServiceManager* servicer)

--- a/src/game.h
+++ b/src/game.h
@@ -69,6 +69,13 @@ enum GameState_t
 	GAMESTATE_LAST = GAMESTATE_SHUTDOWN
 };
 
+enum DebugOverlay_t
+{
+	DEBUG_OVERLAY_HITBOXES,
+	DEBUG_OVERLAY_EFFECT_COUNT,
+	DEBUG_OVERLAY_VELOCITY_ARROWS
+};
+
 enum LightState_t
 {
 	LIGHT_STATE_DAY,
@@ -180,6 +187,14 @@ class Game
 
 		void setWorldType(WorldType_t type) {worldType = type;}
 		WorldType_t getWorldType() const {return worldType;}
+		bool setDebugOverlayEnabled(DebugOverlay_t overlay, bool enabled);
+		bool toggleDebugOverlay(DebugOverlay_t overlay);
+		bool isDebugOverlayEnabled(DebugOverlay_t overlay) const;
+
+		bool setArpgModeEnabled(bool enabled);
+		bool toggleArpgMode();
+		bool isArpgModeEnabled() const {return arpgModeEnabled;}
+
 
 		Cylinder* internalGetCylinder(Player* player, const Position& pos);
 		Thing* internalGetThing(Player* player, const Position& pos, int32_t index,
@@ -664,6 +679,11 @@ class Game
 
 		GameState_t gameState;
 		WorldType_t worldType;
+
+		bool debugOverlayHitboxes;
+		bool debugOverlayEffectCount;
+		bool debugOverlayVelocityArrows;
+		bool arpgModeEnabled;
 
 		ServiceManager* services;
 		Map* map;

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -389,6 +389,8 @@ bool TalkAction::loadFunction(const std::string& functionName)
 		m_function = addSkill;
 	else if(m_functionName == "ghost")
 		m_function = ghost;
+	else if(m_functionName == "arpgdebug")
+		m_function = arpgDebug;
 	else if(m_functionName == "software")
 		m_function = software;
 	else
@@ -1327,6 +1329,26 @@ bool TalkAction::ghost(Creature* creature, const std::string&, const std::string
 		player->sendTextMessage(MSG_INFO_DESCR, "You are now invisible.");
 		player->sendMagicEffect(player->getPosition(), MAGIC_EFFECT_YALAHARIGHOST);
 	}
+
+	return true;
+
+bool TalkAction::arpgDebug(Creature* creature, const std::string&, const std::string&)
+{
+	Player* player = creature->getPlayer();
+	if(!player)
+		return false;
+
+	bool hitboxes = g_game.toggleDebugOverlay(DEBUG_OVERLAY_HITBOXES);
+	bool effectCount = g_game.toggleDebugOverlay(DEBUG_OVERLAY_EFFECT_COUNT);
+	bool velocity = g_game.toggleDebugOverlay(DEBUG_OVERLAY_VELOCITY_ARROWS);
+	bool arpgMode = g_game.toggleArpgMode();
+
+	std::ostringstream ss;
+	ss << "ARPG debug overlays: hitboxes=" << (hitboxes ? "ON" : "OFF")
+		<< ", effect count=" << (effectCount ? "ON" : "OFF")
+		<< ", velocity arrows=" << (velocity ? "ON" : "OFF")
+		<< ". ARPG mode is " << (arpgMode ? "ENABLED" : "DISABLED") << '.';
+	player->sendTextMessage(MSG_INFO_DESCR, ss.str());
 
 	return true;
 }

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -107,6 +107,7 @@ class TalkAction : public Event
 		static TalkFunction diagnostics;
 		static TalkFunction addSkill;
 		static TalkFunction ghost;
+		static TalkFunction arpgDebug;
 		static TalkFunction software;
 
 		std::string m_words, m_functionName;


### PR DESCRIPTION
## Summary
- add a GM-only /arpgdebug talk action that toggles debug overlays and ARPG mode during runtime
- expose Game helpers to flip hitbox, effect count, and velocity debug overlays with logging
- register the new talk action in the XML configuration for GM commands

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab9b5f7208330a24a28a5eba22c5c